### PR TITLE
Set PYTHONPATH to fix s3cmd

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -45,6 +45,7 @@ export INCLUDE_PATH="\$HOME/.apt/usr/include:\$INCLUDE_PATH"
 export CPATH="\$INCLUDE_PATH"
 export CPPPATH="\$INCLUDE_PATH"
 export PKG_CONFIG_PATH="\$HOME/.apt/usr/lib/x86_64-linux-gnu/pkgconfig:\$HOME/.apt/usr/lib/i386-linux-gnu/pkgconfig:\$HOME/.apt/usr/lib/pkgconfig:\$PKG_CONFIG_PATH"
+export PYTHONPATH="\$HOME/.apt/usr/lib/python2.7/dist-packages"
 EOF
 
 for DEB in $(ls -1 $APT_CACHE_DIR/archives/*.deb); do


### PR DESCRIPTION
I'm getting a s3cmd error when using the sync feature:

2017-06-29T01:06:25.426852+00:00 app[web.1]: Traceback (most recent call last):
2017-06-29T01:06:25.426853+00:00 app[web.1]:   File "/app/.apt/usr/bin/s3cmd", line 2897, in <module>
2017-06-29T01:06:25.426854+00:00 app[web.1]:     from S3.ExitCodes import *
2017-06-29T01:06:25.426854+00:00 app[web.1]: ImportError: No module named S3.ExitCodes
2017-06-29T01:06:25.426856+00:00 app[web.1]:
2017-06-29T01:06:25.426887+00:00 app[web.1]: Your sys.path contains these entries:
2017-06-29T01:06:25.426890+00:00 app[web.1]: 	/app/.apt/usr/bin
2017-06-29T01:06:25.426892+00:00 app[web.1]: 	/usr/lib/python2.7
2017-06-29T01:06:25.426910+00:00 app[web.1]: 	/usr/lib/python2.7/plat-x86_64-linux-gnu
2017-06-29T01:06:25.426911+00:00 app[web.1]: 	/usr/lib/python2.7/lib-tk
2017-06-29T01:06:25.426914+00:00 app[web.1]: 	/usr/lib/python2.7/lib-old
2017-06-29T01:06:25.426932+00:00 app[web.1]: 	/usr/lib/python2.7/lib-dynload
2017-06-29T01:06:25.426934+00:00 app[web.1]: 	/usr/local/lib/python2.7/dist-packages
2017-06-29T01:06:25.426936+00:00 app[web.1]: 	/usr/lib/python2.7/dist-packages
2017-06-29T01:06:25.426938+00:00 app[web.1]: Now the question is where have the s3cmd modules been installed?
2017-06-29T01:06:25.426962+00:00 app[web.1]:
2017-06-29T01:06:25.426963+00:00 app[web.1]: !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
2017-06-29T01:06:25.426964+00:00 app[web.1]:     An unexpected error has occurred.
2017-06-29T01:06:25.426964+00:00 app[web.1]:   Please try reproducing the error using
2017-06-29T01:06:25.426965+00:00 app[web.1]:   the latest s3cmd code from the git master
2017-06-29T01:06:25.426965+00:00 app[web.1]:   branch found at:
2017-06-29T01:06:25.426966+00:00 app[web.1]:     https://github.com/s3tools/s3cmd
2017-06-29T01:06:25.426966+00:00 app[web.1]:   and have a look at the known issues list:
2017-06-29T01:06:25.426967+00:00 app[web.1]:     https://github.com/s3tools/s3cmd/wiki/Common-known-issues-and-their-solutions
2017-06-29T01:06:25.426967+00:00 app[web.1]:   If the error persists, please report the
2017-06-29T01:06:25.426968+00:00 app[web.1]:   above lines (removing any private
2017-06-29T01:06:25.426968+00:00 app[web.1]:   info as necessary) to:
2017-06-29T01:06:25.426969+00:00 app[web.1]:    s3tools-bugs@lists.sourceforge.net
2017-06-29T01:06:25.426970+00:00 app[web.1]: !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!

Setting the PYTHONPATH seems to fix it.