### PR TITLE
Create json files as valid JSON

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -62,7 +62,7 @@ curl --silent -o ngrok.zip -L "https://bin.equinox.io/c/4VmDzA7iaHb/ngrok-stable
 unzip ngrok.zip -d $BUILD_DIR/bin > /dev/null 2>&1
 echo "done"
 
-minecraft_version=${MINECRAFT_VERSION:-"1.11.2"}
+minecraft_version=${MINECRAFT_VERSION:-"1.12"}
 minecraft_url="https://s3.amazonaws.com/Minecraft.Download/versions/${minecraft_version}/minecraft_server.${minecraft_version}.jar"
 
 echo -n "-----> Installing Minecraft ${minecraft_version}... "

--- a/opt/minecraft
+++ b/opt/minecraft
@@ -22,10 +22,9 @@ sync_pid=$!
 
 # create server config
 echo "server-port=${mc_port}" >> /app/server.properties
-touch whitelist.json
-touch banned-players.json
-touch banned-ips.json
-touch ops.json
+for f in whitelist banned-players banned-ips ops; do
+  test ! -f $f.json && echo -n "[]" > $f.json
+done
 
 limit=$(ulimit -u)
 case $limit in


### PR DESCRIPTION
Minecraft 1.12 will stop with an error if the JSON files don't contain valid JSON (and an empty file isn't valid JSON.)